### PR TITLE
release: assemble updater latest.json ourselves; bump to 0.6.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,8 +385,87 @@ jobs:
             gh release upload "${{ github.ref_name }}" "$dmg" --clobber
           done
 
+      # ``tauri-action`` is supposed to assemble ``latest.json`` for
+      # the auto-updater when ``includeUpdaterJson: true`` is set,
+      # but on Tauri 2.x + product names with spaces ("Ember Code")
+      # it consistently logs ``Signature not found for the updater
+      # JSON. Skipping upload...`` and the file never makes it to
+      # the release (verified across v0.6.0 + v0.6.1). The .app.tar.gz
+      # IS signed and the .sig sits next to it on disk — we just
+      # stash it as a workflow artifact so the ``updater-json`` job
+      # below can read both arches' sigs and write the file ourselves.
+      - name: Stash updater signature (macOS)
+        if: matrix.platform == 'macos-14'
+        uses: actions/upload-artifact@v4
+        with:
+          name: updater-sig-${{ contains(matrix.args, 'aarch64') && 'aarch64' || 'x86_64' }}
+          path: clients/tauri/src-tauri/target/*/release/bundle/macos/*.app.tar.gz.sig
+          if-no-files-found: error
+          retention-days: 1
+
+  # Build ``latest.json`` ourselves and attach it to the release —
+  # see the long comment in the matrix step above. Mac-only for now;
+  # Windows + Linux updaters use different bundle types we don't
+  # currently ship signed payloads for.
+  updater-json:
+    needs: [prepare-release, build-tauri]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download macOS updater signatures
+        uses: actions/download-artifact@v4
+        with:
+          pattern: updater-sig-*
+          path: /tmp/sigs/
+      - name: Assemble + upload latest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          # Strip leading "v" so ``version`` matches what the
+          # updater plugin compares against ``CARGO_PKG_VERSION``.
+          VERSION="${TAG#v}"
+          PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          BASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+
+          # Sigs come down inside per-arch directories; the
+          # filename inside is ``Ember Code.app.tar.gz.sig`` (with
+          # a space) so we glob for it instead of hard-coding.
+          AARCH64_SIG="$(cat /tmp/sigs/updater-sig-aarch64/*.app.tar.gz.sig)"
+          X64_SIG="$(cat /tmp/sigs/updater-sig-x86_64/*.app.tar.gz.sig)"
+
+          # ``jq -Rs .`` reads the file content as a raw string and
+          # JSON-quotes it (escapes newlines / quotes correctly).
+          AARCH64_JSON="$(printf '%s' "$AARCH64_SIG" | jq -Rs .)"
+          X64_JSON="$(printf '%s' "$X64_SIG" | jq -Rs .)"
+
+          cat > /tmp/latest.json <<EOF
+          {
+            "version": "${VERSION}",
+            "notes": "See the GitHub release page for the changelog.",
+            "pub_date": "${PUB_DATE}",
+            "platforms": {
+              "darwin-aarch64": {
+                "signature": ${AARCH64_JSON},
+                "url": "${BASE_URL}/Ember.Code_aarch64.app.tar.gz"
+              },
+              "darwin-x86_64": {
+                "signature": ${X64_JSON},
+                "url": "${BASE_URL}/Ember.Code_x64.app.tar.gz"
+              }
+            }
+          }
+          EOF
+          # Sanity-check the JSON before we ship it.
+          jq . /tmp/latest.json >/dev/null
+          gh release upload "$TAG" /tmp/latest.json --clobber
+          echo "latest.json uploaded:"
+          cat /tmp/latest.json
+
   github-release:
-    needs: [prepare-release, publish-pypi, build-jetbrains-plugin, build-vscode-plugin, build-tauri]
+    needs: [prepare-release, publish-pypi, build-jetbrains-plugin, build-vscode-plugin, build-tauri, updater-json]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/clients/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/clients/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,21 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <h3>0.6.2</h3>
+        <ul>
+          <li>Release-pipeline fix: <code>latest.json</code> for the
+              Tauri auto-updater is now assembled and uploaded by
+              our own workflow step. <code>tauri-action</code>'s
+              built-in path was silently skipping with "Signature
+              not found for the updater JSON" on Tauri 2 + product
+              names with spaces, so previous releases shipped
+              without the updater manifest and clients couldn't
+              detect new versions. Users on 0.6.0 / 0.6.1 will
+              receive an update prompt for 0.6.2.</li>
+          <li>No JetBrains-side changes in this release; bundled
+              <code>ignite-ember</code> bumped to 0.6.2 in lockstep
+              via <code>build.gradle.kts</code>.</li>
+        </ul>
         <h3>0.6.1</h3>
         <ul>
           <li>Frosted-glass header + sidebar — messages scrolling

--- a/clients/tauri/src-tauri/Cargo.lock
+++ b/clients/tauri/src-tauri/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "ember-code-app"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "core-foundation-sys",
  "dirs 5.0.1",

--- a/clients/tauri/src-tauri/Cargo.toml
+++ b/clients/tauri/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "ember-code-app"
 # Kept in lockstep with ``pyproject.toml`` by
 # ``scripts/sync-version.mjs`` (also drives the runtime's
 # ``IGNITE_EMBER_VERSION`` pin via ``CARGO_PKG_VERSION``).
-version = "0.6.1"
+version = "0.6.2"
 description = "Ember Code — standalone desktop app"
 edition = "2021"
 

--- a/clients/tauri/src-tauri/tauri.conf.json
+++ b/clients/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ember Code",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "sh.ignite-ember.desktop",
   "build": {
     "frontendDist": "../../web/dist",

--- a/clients/vscode/package-lock.json
+++ b/clients/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-code-vscode",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-code-vscode",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ember-code-vscode",
   "displayName": "Ember Code",
   "description": "AI coding assistant with multi-agent orchestration — chat panel with zero-touch backend install",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "ignite-ember",
   "license": "MIT",
   "icon": "icon.png",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ignite-ember"
-version = "0.6.1"
+version = "0.6.2"
 description = "AI coding assistant with multi-agent orchestration — TUI, web, JetBrains, VSCode, and Tauri clients"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "ignite-ember"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "agno", extra = ["ddg", "mcp", "openai", "sql", "sqlite"] },


### PR DESCRIPTION
## Summary

Fixes the Tauri auto-updater across the v0.6.x line. Every release we've shipped (v0.6.0 + v0.6.1) is missing ``latest.json``: ``tauri-action``'s ``includeUpdaterJson: true`` path silently skips with ``Signature not found for the updater JSON. Skipping upload...`` on Tauri 2 + product names with spaces ("Ember Code"). Without ``latest.json``, the updater endpoint returns 404 and the app never sees a new version.

This PR builds ``latest.json`` ourselves:

- Each macOS ``build-tauri`` matrix leg stashes its ``.app.tar.gz.sig`` as a workflow artifact named per arch (``updater-sig-aarch64`` / ``updater-sig-x86_64``).
- New ``updater-json`` job downloads both, ``jq``-quotes the raw signature, writes the standard Tauri-v2 manifest (version / pub_date / platforms map for ``darwin-aarch64`` + ``darwin-x86_64``), and ``gh release upload --clobber``s it. ``github-release`` ``needs`` the new job so the release isn't finalised until the manifest is up.
- The signed ``.app.tar.gz`` payloads were already correct — we just attach the manifest pointing at them. Updater pubkey in ``tauri.conf.json`` is unchanged, so v0.6.0 / v0.6.1 clients verify v0.6.2's signatures with the key they already trust.

Bumped to v0.6.2 across pyproject.toml, Tauri Cargo + tauri.conf.json, VSCode package.json, JetBrains change-notes (plus Cargo + npm lockfiles).

Windows + Linux updater payloads are deferred — they need different signed bundle types (``.nsis.zip`` / ``.AppImage`` with extra signing flags) that the matrix doesn't currently produce.

## Test plan

- [ ] Pipeline jobs all green on the v0.6.2 tag — especially the new ``updater-json`` job.
- [ ] After the release publishes: ``gh release view v0.6.2 --json assets --jq '[.assets[].name]'`` lists ``latest.json``.
- [ ] ``curl -sL https://github.com/ignite-ember/ember__code/releases/latest/download/latest.json | jq .`` returns the manifest with both ``darwin-aarch64`` and ``darwin-x86_64`` entries pointing at the actual asset URLs.
- [ ] ``jq -r .platforms."darwin-aarch64".signature`` is the full multi-line minisign block from the matching ``.app.tar.gz.sig``.
- [ ] Running installed v0.6.0 / v0.6.1 mac app: ``Check for Updates…`` (Ember Code menu) detects v0.6.2 and offers to install.
- [ ] After install: app reports v0.6.2 in About, ``CARGO_PKG_VERSION`` runtime check matches.