### PR TITLE
release: find-based sig stash, retry updater latest.json (v0.6.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,16 +390,40 @@ jobs:
       # but on Tauri 2.x + product names with spaces ("Ember Code")
       # it consistently logs ``Signature not found for the updater
       # JSON. Skipping upload...`` and the file never makes it to
-      # the release (verified across v0.6.0 + v0.6.1). The .app.tar.gz
-      # IS signed and the .sig sits next to it on disk — we just
-      # stash it as a workflow artifact so the ``updater-json`` job
-      # below can read both arches' sigs and write the file ourselves.
+      # the release (verified across v0.6.0 / v0.6.1 / v0.6.2). The
+      # ``.app.tar.gz`` IS signed and the ``.sig`` sits next to it
+      # on disk — we copy it to a no-spaces tmp path here so the
+      # ``updater-json`` job below can read both arches' sigs and
+      # write the manifest ourselves.
+      #
+      # Why ``find`` + ``cp`` instead of upload-artifact's glob:
+      # ``actions/upload-artifact`` with
+      # ``target/*/release/bundle/macos/*.app.tar.gz.sig`` failed on
+      # the v0.6.2 run with "No files were found" even though the
+      # file is at that exact path. ``find`` resolves the path
+      # deterministically (handles the space in "Ember Code" and the
+      # per-arch ``target/<triple>`` dir without any glob quirks).
       - name: Stash updater signature (macOS)
+        if: matrix.platform == 'macos-14'
+        run: |
+          set -euo pipefail
+          SIG=$(find clients/tauri/src-tauri/target -name '*.app.tar.gz.sig' -print -quit)
+          if [ -z "$SIG" ]; then
+            echo "::error::No .app.tar.gz.sig produced — tauri-action signing didn't run?"
+            echo "Listing bundle macos dir for debugging:"
+            find clients/tauri/src-tauri/target -path '*/release/bundle/macos/*' -maxdepth 8 -print || true
+            exit 1
+          fi
+          echo "Found sig: $SIG"
+          mkdir -p /tmp/updater-sig
+          cp "$SIG" /tmp/updater-sig/updater.sig
+          ls -la /tmp/updater-sig/
+      - name: Upload updater signature artifact
         if: matrix.platform == 'macos-14'
         uses: actions/upload-artifact@v4
         with:
           name: updater-sig-${{ contains(matrix.args, 'aarch64') && 'aarch64' || 'x86_64' }}
-          path: clients/tauri/src-tauri/target/*/release/bundle/macos/*.app.tar.gz.sig
+          path: /tmp/updater-sig/updater.sig
           if-no-files-found: error
           retention-days: 1
 
@@ -430,11 +454,13 @@ jobs:
           PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           BASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
 
-          # Sigs come down inside per-arch directories; the
-          # filename inside is ``Ember Code.app.tar.gz.sig`` (with
-          # a space) so we glob for it instead of hard-coding.
-          AARCH64_SIG="$(cat /tmp/sigs/updater-sig-aarch64/*.app.tar.gz.sig)"
-          X64_SIG="$(cat /tmp/sigs/updater-sig-x86_64/*.app.tar.gz.sig)"
+          # Each macOS matrix leg copied its ``.app.tar.gz.sig`` to
+          # ``/tmp/updater-sig/updater.sig`` before uploading the
+          # artifact, so the filename inside each download dir is
+          # the stable ``updater.sig`` (no space-in-filename glob
+          # surprises like the v0.6.2 attempt hit).
+          AARCH64_SIG="$(cat /tmp/sigs/updater-sig-aarch64/updater.sig)"
+          X64_SIG="$(cat /tmp/sigs/updater-sig-x86_64/updater.sig)"
 
           # ``jq -Rs .`` reads the file content as a raw string and
           # JSON-quotes it (escapes newlines / quotes correctly).

--- a/clients/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/clients/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,23 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <h3>0.6.3</h3>
+        <ul>
+          <li>Re-attempt of the 0.6.2 updater fix. The previous
+              workflow used <code>actions/upload-artifact</code>'s
+              glob to stash <code>.app.tar.gz.sig</code> from the
+              macOS build dirs, but the glob silently matched zero
+              files even though the file was at exactly that path,
+              failing both macOS matrix legs. Switched to a
+              <code>find</code> + <code>cp</code> step that copies
+              the sig to a stable no-spaces path before the
+              upload-artifact step picks it up.</li>
+          <li>Same set of features as 0.6.1 — frosted-glass header
+              / sidebar, custom scroll indicators, faster
+              post-stream tail, knowledge-index warmup, window-drag
+              from the chat header, dark-tile app icon, generic
+              DMG installer icon.</li>
+        </ul>
         <h3>0.6.2</h3>
         <ul>
           <li>Release-pipeline fix: <code>latest.json</code> for the

--- a/clients/tauri/src-tauri/Cargo.lock
+++ b/clients/tauri/src-tauri/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "ember-code-app"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "core-foundation-sys",
  "dirs 5.0.1",

--- a/clients/tauri/src-tauri/Cargo.toml
+++ b/clients/tauri/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "ember-code-app"
 # Kept in lockstep with ``pyproject.toml`` by
 # ``scripts/sync-version.mjs`` (also drives the runtime's
 # ``IGNITE_EMBER_VERSION`` pin via ``CARGO_PKG_VERSION``).
-version = "0.6.2"
+version = "0.6.3"
 description = "Ember Code — standalone desktop app"
 edition = "2021"
 

--- a/clients/tauri/src-tauri/tauri.conf.json
+++ b/clients/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ember Code",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "sh.ignite-ember.desktop",
   "build": {
     "frontendDist": "../../web/dist",

--- a/clients/vscode/package-lock.json
+++ b/clients/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-code-vscode",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-code-vscode",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ember-code-vscode",
   "displayName": "Ember Code",
   "description": "AI coding assistant with multi-agent orchestration — chat panel with zero-touch backend install",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "ignite-ember",
   "license": "MIT",
   "icon": "icon.png",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ignite-ember"
-version = "0.6.2"
+version = "0.6.3"
 description = "AI coding assistant with multi-agent orchestration — TUI, web, JetBrains, VSCode, and Tauri clients"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "ignite-ember"
-version = "0.6.1"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "agno", extra = ["ddg", "mcp", "openai", "sql", "sqlite"] },


### PR DESCRIPTION
## Summary

v0.6.2 stalled because both macOS matrix legs failed at the new "Stash updater signature" step with ``No files were found with the provided path`` — even though the build log earlier showed the ``.app.tar.gz.sig`` at exactly that path. ``actions/upload-artifact@v4``'s glob silently matched zero files; likely a quirk with the space in the product name + the per-arch wildcard, but no useful error past "no files found."

Switched to a deterministic two-step approach: a ``run:`` step uses ``find`` to locate the sig, copies it to ``/tmp/updater-sig/updater.sig`` (no spaces, fixed name), then ``upload-artifact`` ships that single file. The ``updater-json`` job reads ``updater-sig-<arch>/updater.sig`` instead of globbing for ``*.app.tar.gz.sig``. If ``find`` returns empty, the step prints the bundle dir listing before exit so we don't have to guess again.

Bumps to v0.6.3 (v0.6.2 release exists but is incomplete — no ``latest.json``, both macOS Tauri build jobs failed).

## Test plan

- [ ] CI green on this PR.
- [ ] After v0.6.3 tag publishes: ``gh release view v0.6.3 --json assets --jq '[.assets[].name]'`` shows ``latest.json`` plus the usual 11 artifacts.
- [ ] ``curl -sL https://github.com/ignite-ember/ember__code/releases/latest/download/latest.json | jq .`` returns the manifest with both ``darwin-aarch64`` + ``darwin-x86_64`` entries.
- [ ] Installed v0.6.0 mac app prompts for update on next launch / "Check for Updates…".